### PR TITLE
before using pip, ensure system pkg dependencies are installed

### DIFF
--- a/manifests/collector/install.pp
+++ b/manifests/collector/install.pp
@@ -35,8 +35,9 @@ define diamond::collector::install (
 
   if $python_packages {
     create_resources('::python::pip', $python_packages, {
-      proxy  => $diamond::pip_proxy,
-      before => Vcsrepo["${title}-repo"],
+      proxy   => $diamond::pip_proxy,
+      require => $system_packages,
+      before  => Vcsrepo["${title}-repo"],
     })
   }
 


### PR DESCRIPTION
pip pkgs may have additional dependencies that are only satisfied via system packages, so add a 'require' for those to create the relationship.